### PR TITLE
Adjusted costs for cargo pods using FSfuelSwitch

### DIFF
--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Cargo_375_01.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Cargo_375_01.cfg
@@ -23,7 +23,7 @@ breakingTorque = 12690
 // --- editor parameters ---
 TechRequired = veryHeavyRocketry
 entryCost = 7600
-cost = 0
+cost = 1000
 category = Utility
 subcategory = 0
 title = 'Honeybadger' Cargo Pod
@@ -61,7 +61,7 @@ MODULE
   name = FSfuelSwitch
   resourceNames = Ore;Water;Substrate;Minerals;Karbonite;LiquidFuel,Oxidizer;MonoPropellant;Uraninite;RocketParts;
   resourceAmounts = 3000;15000;3000;3000;3000;1350,1650;3000;3000;3000;
-  tankCost = 10500;1000;5000;12500;5300;1900;2000;2000;2000;
+  tankCost = 10500;12;4500;12000;4800;1377;3600;10500;15000;
   hasGUI = false
 }
 

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Cargo_375_02.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Cargo_375_02.cfg
@@ -34,7 +34,7 @@ breakingTorque = 1410
 // --- editor parameters ---
 TechRequired = veryHeavyRocketry
 entryCost = 7600
-cost = 0
+cost = 3000
 category = Utility
 subcategory = 0
 title = 'Honeybadger' Cargo Pod (Jumbo)
@@ -71,7 +71,7 @@ MODULE
   name = FSfuelSwitch
   resourceNames = Ore;Water;Substrate;Minerals;Karbonite;LiquidFuel,Oxidizer;MonoPropellant;Uraninite;RocketParts;
   resourceAmounts = 9000;45000;9000;9000;9000;4050,4950;9000;9000;9000;
-  tankCost = 31500;3000;15000;37500;15900;5700;5000;5000;5000;
+  tankCost = 31500;36;13500;36000;14400;4131;10800;31500;45000;
   hasGUI = false
 }
 

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Kontainer_01.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Kontainer_01.cfg
@@ -65,7 +65,7 @@ MODULE
   name = FSfuelSwitch
   resourceNames = Ore;Water;Substrate;Minerals;Karbonite;LiquidFuel,Oxidizer;RocketParts;Metal;Chemicals;Polymers;
   resourceAmounts = 9000;45000;9000;9000;9000;4050,4950;9000;9000;9000;9000;
-  tankCost = 31500;36;13500;36000;14400;4131;4500090;630000;720000;360000;
+  tankCost = 31500;36;13500;36000;14400;4131;45000;630000;720000;360000;
   hasGUI = false
 }
 

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Kontainer_01.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Kontainer_01.cfg
@@ -65,7 +65,7 @@ MODULE
   name = FSfuelSwitch
   resourceNames = Ore;Water;Substrate;Minerals;Karbonite;LiquidFuel,Oxidizer;RocketParts;Metal;Chemicals;Polymers;
   resourceAmounts = 9000;45000;9000;9000;9000;4050,4950;9000;9000;9000;9000;
-  tankCost = 31500;3000;15000;37500;15900;5700;37500;37500;37500;37500;
+  tankCost = 31500;36;13500;36000;14400;4131;4500090;630000;720000;360000;
   hasGUI = false
 }
 

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Kontainer_02.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Kontainer_02.cfg
@@ -29,7 +29,7 @@ breakingTorque = 203040
 // --- editor parameters ---
 TechRequired = veryHeavyRocketry
 entryCost = 7600
-cost = 3800
+cost = 7600
 category = Utility
 subcategory = 0
 title = Kontainer Mark II
@@ -67,7 +67,7 @@ MODULE
   name = FSfuelSwitch
   resourceNames = Ore;Water;Substrate;Minerals;Karbonite;LiquidFuel,Oxidizer;RocketParts;Metal;Chemicals;Polymers;
   resourceAmounts = 13500;67500;13500;13500;13500;6075,7425;13500;13500;13500;13500;
-  tankCost = 47500;4500;22500;55000;24000;9000;55000;55000;55000;55000;
+  tankCost = 47250;54;20250;54000;21600;6200;67500;945000;1080000;540000;
   hasGUI = false
 }
 

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Kontainer_03.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Kontainer_03.cfg
@@ -40,7 +40,7 @@ breakingTorque = 203040
 // --- editor parameters ---
 TechRequired = veryHeavyRocketry
 entryCost = 7600
-cost = 3800
+cost = 15200
 category = Utility
 subcategory = 0
 title = Kontainer Pod
@@ -78,7 +78,7 @@ MODULE
   name = FSfuelSwitch
   resourceNames = Ore;Water;Substrate;Minerals;Karbonite;LiquidFuel,Oxidizer;RocketParts;Metal;Chemicals;Polymers;
   resourceAmounts = 27000;135000;27000;27000;27000;12150,14850;27000;27000;27000;27000;
-  tankCost = 95000;9000;45000;110000;48000;18000;
+  tankCost = 94500;108;40500;108000;43200;12393;135000;1890000;2160000;1080000;
   hasGUI = false
 }
 


### PR DESCRIPTION
All tankCost values are just resourceAmounts*unitPrice, slightly adjusted base costs -- all tanks cost the same when empty (modulo one instance of rounding), tested than no tanks go negative.