### PR TITLE
Corrected FSfuelSwitcher masses,  3.75m tech tree

### DIFF
--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_CargoBay_375_01.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_CargoBay_375_01.cfg
@@ -25,7 +25,7 @@ breakingForce = 2030
 breakingTorque = 2030
 
 // --- editor parameters ---
-TechRequired = veryHeavyRocketry
+TechRequired = heavierRocketry
 entryCost = 7600
 cost = 3800
 category = Utility
@@ -107,6 +107,3 @@ MODULE
 }
 
 }
-
-
-

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Cargo_375_01.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Cargo_375_01.cfg
@@ -21,7 +21,7 @@ breakingForce = 12690
 breakingTorque = 12690
 
 // --- editor parameters ---
-TechRequired = veryHeavyRocketry
+TechRequired = heavierRocketry
 entryCost = 7600
 cost = 1000
 category = Utility

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Cargo_375_01.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Cargo_375_01.cfg
@@ -47,7 +47,7 @@ MODULE
   name = FStextureSwitch2
   moduleId = 0;
   textureNames = UmbraSpaceIndustries/FTT/Assets/DECAL;UmbraSpaceIndustries/FTT/Assets/DECAL;UmbraSpaceIndustries/FTT/Assets/DECAL;UmbraSpaceIndustries/FTT/Assets/DECAL;UmbraSpaceIndustries/FTT/Assets/DECAL;UmbraSpaceIndustries/FTT/Assets/DECAL;UmbraSpaceIndustries/FTT/Assets/DECAL;UmbraSpaceIndustries/FTT/Assets/DECAL;UmbraSpaceIndustries/FTT/Assets/DECAL;
-  objectNames = 
+  objectNames =
   textureDisplayNames = Ore;Water;Substrate;Minerals;Karbonite;LFO;MonoPropellant;Uraninite;RocketParts;
   useFuelSwitchModule = true
   fuelTankSetups = 0;1;2;3;4;5;6;7;8;
@@ -62,6 +62,8 @@ MODULE
   resourceNames = Ore;Water;Substrate;Minerals;Karbonite;LiquidFuel,Oxidizer;MonoPropellant;Uraninite;RocketParts;
   resourceAmounts = 3000;15000;3000;3000;3000;1350,1650;3000;3000;3000;
   tankCost = 10500;12;4500;12000;4800;1377;3600;10500;15000;
+	basePartMass = 0.5
+	tankMass = 0;0;0;0;0;0;0;0;0;
   hasGUI = false
 }
 
@@ -96,6 +98,3 @@ MODULE
 }
 
 }
-
-
-

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Cargo_375_02.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Cargo_375_02.cfg
@@ -57,7 +57,7 @@ MODULE
 {
   name = FStextureSwitch2
   textureNames = UmbraSpaceIndustries/FTT/Assets/DECAL;UmbraSpaceIndustries/FTT/Assets/DECAL;UmbraSpaceIndustries/FTT/Assets/DECAL;UmbraSpaceIndustries/FTT/Assets/DECAL;UmbraSpaceIndustries/FTT/Assets/DECAL;UmbraSpaceIndustries/FTT/Assets/DECAL;UmbraSpaceIndustries/FTT/Assets/DECAL;UmbraSpaceIndustries/FTT/Assets/DECAL;UmbraSpaceIndustries/FTT/Assets/DECAL;
-  objectNames = 
+  objectNames =
   textureDisplayNames = Ore;Water;Substrate;Minerals;Karbonite;LFO;MonoPropellant;Uraninite;RocketParts;
   useFuelSwitchModule = true
   fuelTankSetups = 0;1;2;3;4;5;6;7;8;
@@ -72,6 +72,8 @@ MODULE
   resourceNames = Ore;Water;Substrate;Minerals;Karbonite;LiquidFuel,Oxidizer;MonoPropellant;Uraninite;RocketParts;
   resourceAmounts = 9000;45000;9000;9000;9000;4050,4950;9000;9000;9000;
   tankCost = 31500;36;13500;36000;14400;4131;10800;31500;45000;
+	basePartMass = 1.5
+	tankMass = 0;0;0;0;0;0;0;0;0;
   hasGUI = false
 }
 
@@ -99,7 +101,7 @@ MODULE
   name = FStextureSwitch2
   textureNames = UmbraSpaceIndustries/FTT/Assets/CargoDecal;UmbraSpaceIndustries/FTT/Assets/CargoDecal_GRY;UmbraSpaceIndustries/FTT/Assets/CargoDecal_ORG;UmbraSpaceIndustries/FTT/Assets/CargoDecal_BRN;
   objectNames = DECAL;
-  textureDisplayNames = Yellow;Gray;Orange;Brown;  
+  textureDisplayNames = Yellow;Gray;Orange;Brown;
   nextButtonText = Next Trim Texture
   prevButtonText = Previous Trim Texture
   statusText = Trim Color
@@ -107,6 +109,3 @@ MODULE
 
 
 }
-
-
-

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Cargo_375_02.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Cargo_375_02.cfg
@@ -32,7 +32,7 @@ breakingForce = 1410
 breakingTorque = 1410
 
 // --- editor parameters ---
-TechRequired = veryHeavyRocketry
+TechRequired = heavierRocketry
 entryCost = 7600
 cost = 3000
 category = Utility

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Command_375_01.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Command_375_01.cfg
@@ -20,7 +20,7 @@ node_stack_top = 0.0, 1.7, 0.0, 0.0, 1.0, 0.0, 1
 
 
 // --- editor parameters ---
-TechRequired = veryHeavyRocketry
+TechRequired = heavierRocketry
 entryCost = 7600
 cost = 3800
 category = Pods
@@ -67,25 +67,25 @@ RESOURCE
 
 MODULE
 {
-	name = ModuleScienceExperiment	
-	
+	name = ModuleScienceExperiment
+
 	experimentID = crewReport
-	
+
 	experimentActionName = Crew Report
 	resetActionName = Discard Crew Report
 	reviewActionName = Review Report
-	
-	useStaging = False	
+
+	useStaging = False
 	useActionGroups = True
-	hideUIwhenUnavailable = True	
+	hideUIwhenUnavailable = True
 	rerunnable = True
-	
+
 	xmitDataScalar = 1.0
 }
 MODULE
 {
 	name = ModuleScienceContainer
-	
+
 	reviewActionName = Review Stored Data
 	storeActionName = Store Experiments
 	evaOnlyStorage = True
@@ -107,7 +107,7 @@ MODULE
   textureDisplayNames = Yellow;Gray;Orange;Brown;
 }
 
-MODULE 
+MODULE
 {
 	name = ExSurveyStation
 }

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Control_375_01.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Control_375_01.cfg
@@ -20,7 +20,7 @@ node_stack_top = 0.0, 0.25, 0.0, 0.0, 1.0, 0.0, 3
 
 
 // --- editor parameters ---
-TechRequired = veryHeavyRocketry
+TechRequired = heavierRocketry
 entryCost = 7600
 cost = 3800
 category = Control
@@ -59,11 +59,11 @@ MODULE
 MODULE
 {
 	name = ModuleReactionWheel
-	
+
 	PitchTorque = 30
 	YawTorque = 30
 	RollTorque = 30
-	
+
 	RESOURCE
 	{
 		name = ElectricCharge
@@ -97,6 +97,3 @@ MODULE
 }
 
 }
-
-
-

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Engine_375_01.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Engine_375_01.cfg
@@ -21,7 +21,7 @@ breakingForce = 12690
 breakingTorque = 12690
 
 // --- editor parameters ---
-TechRequired = veryHeavyRocketry
+TechRequired = heavierRocketry
 entryCost = 7600
 cost = 3800
 category = Propulsion
@@ -81,7 +81,7 @@ MODULE
    	 key = 0 370
   	 key = 1 320
  	}
-	
+
 }
 
 
@@ -94,7 +94,7 @@ MODULE
 
 MODULE
 {
-	name = ModuleAlternator	
+	name = ModuleAlternator
 	RESOURCE
 	{
 		name = ElectricCharge
@@ -120,6 +120,3 @@ RESOURCE
 
 
 }
-
-
-

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Engine_375_02.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Engine_375_02.cfg
@@ -22,7 +22,7 @@ breakingForce = 3173
 breakingTorque = 3173
 
 // --- editor parameters ---
-TechRequired = veryHeavyRocketry
+TechRequired = heavierRocketry
 entryCost = 7600
 cost = 3800
 category = Propulsion
@@ -67,7 +67,7 @@ MODULE
 	engineDecelerationSpeed = 1.00
 	useVelocityCurve = True
 	fxOffset = 0, 0, 0
-	
+
 	PROPELLANT
 	{
 		name = ElectricCharge
@@ -92,7 +92,7 @@ MODULE
             key = 150 0.84 -0.0035 -0.0035
             key = 250 0    -0.016   0
 	}
-	
+
 }
 
 MODULE

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Kontainer_01.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Kontainer_01.cfg
@@ -25,7 +25,7 @@ breakingTorque = 2072
 
 
 // --- editor parameters ---
-TechRequired = veryHeavyRocketry
+TechRequired = heavierRocketry
 entryCost = 7600
 cost = 3800
 category = Utility

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Kontainer_01.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Kontainer_01.cfg
@@ -66,11 +66,10 @@ MODULE
   resourceNames = Ore;Water;Substrate;Minerals;Karbonite;LiquidFuel,Oxidizer;RocketParts;Metal;Chemicals;Polymers;
   resourceAmounts = 9000;45000;9000;9000;9000;4050,4950;9000;9000;9000;9000;
   tankCost = 31500;36;13500;36000;14400;4131;45000;630000;720000;360000;
+	basePartMass = 0.75
+	tankMass = 0;0;0;0;0;0;0;0;0;0;
   hasGUI = false
 }
 
 
 }
-
-
-

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Kontainer_02.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Kontainer_02.cfg
@@ -68,11 +68,10 @@ MODULE
   resourceNames = Ore;Water;Substrate;Minerals;Karbonite;LiquidFuel,Oxidizer;RocketParts;Metal;Chemicals;Polymers;
   resourceAmounts = 13500;67500;13500;13500;13500;6075,7425;13500;13500;13500;13500;
   tankCost = 47250;54;20250;54000;21600;6200;67500;945000;1080000;540000;
+	basePartMass = 0.75
+	tankMass = 0;0;0;0;0;0;0;0;0;0;
   hasGUI = false
 }
 
 
 }
-
-
-

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Kontainer_03.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Kontainer_03.cfg
@@ -79,11 +79,10 @@ MODULE
   resourceNames = Ore;Water;Substrate;Minerals;Karbonite;LiquidFuel,Oxidizer;RocketParts;Metal;Chemicals;Polymers;
   resourceAmounts = 27000;135000;27000;27000;27000;12150,14850;27000;27000;27000;27000;
   tankCost = 94500;108;40500;108000;43200;12393;135000;1890000;2160000;1080000;
+	basePartMass = 3.35
+	tankMass = 0;0;0;0;0;0;0;0;0;0;
   hasGUI = false
 }
 
 
 }
-
-
-

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Reactor_500_01.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Reactor_500_01.cfg
@@ -53,10 +53,10 @@ maxTemp = 3400
       ConverterName = Reactor
 	  StartActionName = Start Reactor
   	  StopActionName = Stop Reactor
-      RecipeInputs = EnrichedUranium, 0.000005
-      RecipeOutputs = DepletedUranium, 0.000005, True, ElectricCharge, 8000, True
+      RecipeInputs = EnrichedUranium, 0.00003
+      RecipeOutputs = DepletedUranium, 0.00003, True, ElectricCharge, 8000, False
   }
-
+  
 RESOURCE
 {
 name = EnrichedUranium
@@ -86,3 +86,6 @@ MODULE
 }
 
 }
+
+
+

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Reactor_500_01.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Reactor_500_01.cfg
@@ -53,10 +53,10 @@ maxTemp = 3400
       ConverterName = Reactor
 	  StartActionName = Start Reactor
   	  StopActionName = Stop Reactor
-      RecipeInputs = EnrichedUranium, 0.00003
-      RecipeOutputs = DepletedUranium, 0.00003, True, ElectricCharge, 8000, False
+      RecipeInputs = EnrichedUranium, 0.000005
+      RecipeOutputs = DepletedUranium, 0.000005, True, ElectricCharge, 8000, True
   }
-  
+
 RESOURCE
 {
 name = EnrichedUranium
@@ -86,6 +86,3 @@ MODULE
 }
 
 }
-
-
-

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Service_375_01.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Service_375_01.cfg
@@ -23,7 +23,7 @@ breakingForce = 12690
 breakingTorque = 12690
 
 // --- editor parameters ---
-TechRequired = veryHeavyRocketry
+TechRequired = heavierRocketry
 entryCost = 7600
 cost = 660000
 category = Utility

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Service_375_01.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Service_375_01.cfg
@@ -50,10 +50,10 @@ MODULE
 	ConverterName = Reactor
 	StartActionName = Start Reactor
 	StopActionName = Stop Reactor
-	RecipeInputs = EnrichedUranium,0.0000075
-	RecipeOutputs = ElectricCharge,2000,False,DepletedUranium,0.0000075,True
-}	
-	
+	RecipeInputs = EnrichedUranium,0.0000025
+	RecipeOutputs = ElectricCharge,2000,True,DepletedUranium,0.0000025,True
+}
+
 RESOURCE
 {
  name = EnrichedUranium
@@ -85,6 +85,3 @@ MODULE
 
 
 }
-
-
-

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Service_375_01.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Service_375_01.cfg
@@ -50,10 +50,10 @@ MODULE
 	ConverterName = Reactor
 	StartActionName = Start Reactor
 	StopActionName = Stop Reactor
-	RecipeInputs = EnrichedUranium,0.0000025
-	RecipeOutputs = ElectricCharge,2000,True,DepletedUranium,0.0000025,True
-}
-
+	RecipeInputs = EnrichedUranium,0.0000075
+	RecipeOutputs = ElectricCharge,2000,False,DepletedUranium,0.0000075,True
+}	
+	
 RESOURCE
 {
  name = EnrichedUranium
@@ -85,3 +85,6 @@ MODULE
 
 
 }
+
+
+

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Structural_375_02.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Structural_375_02.cfg
@@ -26,7 +26,7 @@ node_stack_eng_04 = 0.7, -.35, -0.7, 0.0, 1.0, 0.0, 1
 
 stackSymmetry = 3
 // --- editor parameters ---
-TechRequired = veryHeavyRocketry
+TechRequired = heavierRocketry
 entryCost = 7600
 cost = 3800
 category = Structural
@@ -50,6 +50,3 @@ maxTemp = 3400
 
 
 }
-
-
-

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Structural_375_03.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Structural_375_03.cfg
@@ -24,7 +24,7 @@ breakingTorque = 50760
 
 stackSymmetry = 3
 // --- editor parameters ---
-TechRequired = veryHeavyRocketry
+TechRequired = heavierRocketry
 entryCost = 7600
 cost = 3800
 category = Structural
@@ -48,6 +48,3 @@ maxTemp = 3400
 
 
 }
-
-
-

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Structural_375_04.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Structural_375_04.cfg
@@ -24,7 +24,7 @@ breakingTorque = 103592
 
 stackSymmetry = 3
 // --- editor parameters ---
-TechRequired = veryHeavyRocketry
+TechRequired = heavierRocketry
 entryCost = 7600
 cost = 3800
 category = Structural
@@ -61,6 +61,3 @@ MODULE
 }
 
 }
-
-
-

--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Structural_375_05.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Structural_375_05.cfg
@@ -25,7 +25,7 @@ breakingTorque = 203040
 
 
 // --- editor parameters ---
-TechRequired = veryHeavyRocketry
+TechRequired = heavierRocketry
 entryCost = 7600
 cost = 3800
 category = Structural
@@ -55,6 +55,3 @@ MODULE
 }
 
 }
-
-
-


### PR DESCRIPTION
same fix @Ramarren did in MKS for container masses. FSfuelSwitcher containers should now have the correct mass.

Moved Honeybadger 3.75m parts to the Heavier Rocketry node in the tech tree.