### PR TITLE
Update FTT_Structural_500_05.cfg

### DIFF
--- a/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Structural_500_05.cfg
+++ b/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Structural_500_05.cfg
@@ -29,11 +29,11 @@ MODEL
 // definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 
 node_stack_cargo_01 = .8, 0, 0, 1, 0, 0.0, 3
-node_stack_cargo_02 = -.8, 0, 0, 1, 0, 0.0, 3
+node_stack_cargo_02 = -.8, 0, 0, -1, 0, 0.0, 3
 node_stack_cargo_03 = .8, 7.5, 0, 1, 0, 0.0, 3
-node_stack_cargo_04 = -.8, 7.5, 0, 1, 0, 0.0, 3
+node_stack_cargo_04 = -.8, 7.5, 0, -1, 0, 0.0, 3
 node_stack_cargo_05 = .8, -7.5, 0, 1, 0, 0.0, 3
-node_stack_cargo_06 = -.8, -7.5, 0, 1, 0, 0.0, 3
+node_stack_cargo_06 = -.8, -7.5, 0, -1, 0, 0.0, 3
 
 
 node_stack_bottom_R = 0, -11.25, 0, 0.0, 1.0, 0.0, 3


### PR DESCRIPTION
Fixed Up X of attachment nodes to accommodate stricter node rules in 1.0.  Fixes #80.