### PR TITLE
Correct JSON errors in .version file

### DIFF
--- a/GameData/UmbraSpaceIndustries/FTT/FTT.version
+++ b/GameData/UmbraSpaceIndustries/FTT/FTT.version
@@ -1,11 +1,11 @@
 {
      "NAME":"Freight Transport Tech",
-	 "URL":"https://raw.githubusercontent.com/BobPalmer/FTT/master/GameData/UmbraSpaceIndustries/FTT/FTT.version"
-	 "DOWNLOAD":"https://github.com/BobPalmer/FTT/releases"
+     "URL":"https://raw.githubusercontent.com/BobPalmer/FTT/master/GameData/UmbraSpaceIndustries/FTT/FTT.version",
+     "DOWNLOAD":"https://github.com/BobPalmer/FTT/releases",
      "GITHUB":{
          "USERNAME":"BobPalmer",
          "REPOSITORY":"FTT",
-         "ALLOW_PRE_RELEASE":false,
+         "ALLOW_PRE_RELEASE":false
      },
      "VERSION":{
          "MAJOR":0,
@@ -22,7 +22,7 @@
          "MAJOR":1,
          "MINOR":0,
          "PATCH":0
-     }
+     },
      "KSP_VERSION_MAX":{
          "MAJOR":1,
          "MINOR":0,


### PR DESCRIPTION
The current .version file has JSON format errors and this fixes them.


Note for myself: when this merges https://github.com/KSP-CKAN/NetKAN/blob/master/NetKAN/USI-FTT.netkan can be updated to use an avc vref.