### PR TITLE
Add fuel switch to spherical tanks

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Tank_1000_01.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Tank_1000_01.cfg
@@ -27,10 +27,10 @@ breakingTorque = 203040
 // --- editor parameters ---
 TechRequired = veryHeavyRocketry
 entryCost = 400000
-cost = 43110
+cost = 25000
 category = Propulsion
 subcategory = 0
-title = Jumbo Spherical Liquid Hydrogen Tank
+title = Jumbo Spherical Fuel Tank
 manufacturer = Umbra Space Industries
 description = Useful for carrying large amounts of liquid hydrogen, generally used to fuel nuclear rocket motors.  
 
@@ -54,14 +54,14 @@ MODULE
       name = ModuleConnectedLivingSpace
       passable = true
 }
-
-RESOURCE
+MODULE
 {
-	name = LqdHydrogen
-	amount = 650000
-	maxAmount = 650000
+  name = FSfuelSwitch
+  resourceNames = LqdHydrogen;LiquidFuel,Oxidizer;LiquidFuel
+  resourceAmounts = 650000;46800,57200;93600
+  basePartMass = 9.8
+  tankCost = 23887;47736;74880
 }
-
 }
 
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Tank_500_01.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Tank_500_01.cfg
@@ -27,10 +27,10 @@ breakingTorque = 203040
 // --- editor parameters ---
 TechRequired = veryHeavyRocketry
 entryCost = 50000
-cost = 25000
+cost = 6000
 category = Propulsion
 subcategory = 0
-title = Spherical Liquid Hydrogen Tank
+title = Spherical Fuel Tank
 manufacturer = Umbra Space Industries
 description = Useful for carrying large amounts of liquid hydrogen, generally used to fuel nuclear rocket motors.  
 
@@ -54,14 +54,14 @@ MODULE
       name = ModuleConnectedLivingSpace
       passable = true
 }
-
-RESOURCE
+MODULE
 {
-	name = LqdHydrogen
-	amount = 75000
-	maxAmount = 75000
+  name = FSfuelSwitch
+  resourceNames = LqdHydrogen;LiquidFuel,Oxidizer;LiquidFuel
+  resourceAmounts = 75000;4860,5940;9720
+  basePartMass = 1.5
+  tankCost = 2756;4957;7776
 }
-
 }
 
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Tank_500_02.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Tank_500_02.cfg
@@ -40,10 +40,10 @@ breakingTorque = 203040
 // --- editor parameters ---
 TechRequired = veryHeavyRocketry
 entryCost = 150000
-cost = 75000
+cost = 15000
 category = Propulsion
 subcategory = 0
-title = Spherical Liquid Hydrogen Tank (cluster)
+title = Spherical Fuel Tank (cluster)
 manufacturer = Umbra Space Industries
 description = Useful for carrying large amounts of liquid hydrogen, generally used to fuel nuclear rocket motors.  This model consists of three tanks joined together.  Includes a radial attachment point for attachment to the top of StarLifter cargo racks.
 
@@ -67,12 +67,13 @@ MODULE
       name = ModuleConnectedLivingSpace
       passable = true
 }
-
-RESOURCE
+MODULE
 {
-	name = LqdHydrogen
-	amount = 225000
-	maxAmount = 225000
+  name = FSfuelSwitch
+  resourceNames = LqdHydrogen;LiquidFuel,Oxidizer;LiquidFuel
+  resourceAmounts = 225000;14580,17820;29160
+  basePartMass = 1.5
+  tankCost = 8269;14872;23328
 }
 
 }

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Tank_500_03.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Tank_500_03.cfg
@@ -28,10 +28,10 @@ breakingTorque = 203040
 // --- editor parameters ---
 TechRequired = veryHeavyRocketry
 entryCost = 50000
-cost = 25000
+cost = 6000
 category = Propulsion
 subcategory = 0
-title = Spherical Liquid Hydrogen Tank (Radial)
+title = Spherical Fuel Tank (Radial)
 manufacturer = Umbra Space Industries
 description = Useful for carrying large amounts of liquid hydrogen, generally used to fuel nuclear rocket motors.  Radially attached version.
 
@@ -55,12 +55,13 @@ MODULE
       name = ModuleConnectedLivingSpace
       passable = true
 }
-
-RESOURCE
+MODULE
 {
-	name = LqdHydrogen
-	amount = 75000
-	maxAmount = 75000
+  name = FSfuelSwitch
+  resourceNames = LqdHydrogen;LiquidFuel,Oxidizer;LiquidFuel
+  resourceAmounts = 75000;4860,5940;9720
+  basePartMass = 1.5
+  tankCost = 2756;4957;7776
 }
 
 }


### PR DESCRIPTION
The empty tank prices were way off compared to each other (small tank more expensive than jumbo) so i adjusted them a bit with this change. As a result jumbo is slightly more expensive and small tanks are considerably cheaper.