### PR TITLE
Update FTT_Kontainer_03.cfg

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Kontainer_03.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Kontainer_03.cfg
@@ -64,6 +64,11 @@ bulkheadProfiles = size4
 
 MODULE
 {
+      name = ModuleConnectedLivingSpace
+      passable = true
+}
+MODULE
+{
   name = FStextureSwitch2
   textureNames = UmbraSpaceIndustries/FTT/Assets/Kontainer_00;UmbraSpaceIndustries/FTT/Assets/Kontainer_05;UmbraSpaceIndustries/FTT/Assets/Kontainer_02;UmbraSpaceIndustries/FTT/Assets/Kontainer_03;UmbraSpaceIndustries/FTT/Assets/Kontainer_04;UmbraSpaceIndustries/FTT/Assets/Kontainer_01;UmbraSpaceIndustries/FTT/Assets/Kontainer_06;UmbraSpaceIndustries/FTT/Assets/Kontainer_07;UmbraSpaceIndustries/FTT/Assets/Kontainer_08;UmbraSpaceIndustries/FTT/Assets/Kontainer_09
   objectNames = Kontainer_2


### PR DESCRIPTION
FTT_Kontainer_03 is based on the Starlifter Cargo Rack, which has a CLS = passable in it.  Kontainer_03 does not, so this PR brings it into consistency with the part on which it's based.
