### PR TITLE
Update CTT.cfg

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/CTT.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/CTT.cfg
@@ -1,137 +1,104 @@
 //GiganticRocketry - FTT (Honeybadger)
+@PART[FTT_Command_375_01]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = heavyCommandModules
+}
 @PART[FTT_Cargo_375_01]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = giganticRocketry
+    @TechRequired = metaMaterials
 }
 @PART[FTT_Cargo_375_02]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = giganticRocketry
+    @TechRequired = metaMaterials
 }
 @PART[FTT_CargoBay_375_01]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = giganticRocketry
-}
-@PART[FTT_Command_375_01]:NEEDS[CommunityTechTree]
-{
-    @TechRequired = giganticRocketry
+    @TechRequired = metaMaterials
 }
 @PART[FTT_Control_375_01]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = giganticRocketry
-}
-@PART[FTT_Kontainer_01]:NEEDS[CommunityTechTree]
-{
-    @TechRequired = giganticRocketry
+    @TechRequired = metaMaterials
 }
 @PART[FTT_Structural_375_02]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = giganticRocketry
+    @TechRequired = metaMaterials
 }
 @PART[FTT_Structural_375_03]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = giganticRocketry
+    @TechRequired = metaMaterials
 }
 @PART[FTT_Structural_375_04]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = giganticRocketry
+    @TechRequired = metaMaterials
 }
 @PART[FTT_Structural_375_05]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = giganticRocketry
+    @TechRequired = metaMaterials
 }
 @PART[FTT_Engine_375_01]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = giganticRocketry
+    @TechRequired = specializedFlightSystems
 }
 
 //ColossalRocketry - FTT (StarLifter)
-
-@PART[FTT_Kontainer_02]:NEEDS[CommunityTechTree]
+@PART[FTT_Pod_375_01]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = colossalRocketry
-}
-@PART[FTT_Kontainer_03]:NEEDS[CommunityTechTree]
-{
-    @TechRequired = colossalRocketry
-}
-@PART[FTT_Pod_500_01]:NEEDS[CommunityTechTree]
-{
-    @TechRequired = colossalRocketry
+    @TechRequired = specializedCommandModules
 }
 @PART[FTT_Structural_500_01]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = colossalRocketry
+    @TechRequired = orbitalMegastructures
 }
 @PART[FTT_Structural_500_02]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = colossalRocketry
+    @TechRequired = orbitalMegastructures
 }
 @PART[FTT_Structural_500_03]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = colossalRocketry
+    @TechRequired = orbitalMegastructures
 }
 @PART[FTT_Structural_500_04]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = colossalRocketry
+    @TechRequired = orbitalMegastructures
 }
 @PART[FTT_Structural_500_05]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = colossalRocketry
+    @TechRequired = orbitalMegastructures
 }
 @PART[FTT_Structural_500_06]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = colossalRocketry
+    @TechRequired = orbitalMegastructures
 }
 @PART[FTT_Structural_500_07]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = colossalRocketry
+    @TechRequired = orbitalMegastructures
 }
 @PART[FTT_Structural_500_08]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = colossalRocketry
+    @TechRequired = orbitalMegastructures
 }
 @PART[FTT_Structural_500_09]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = colossalRocketry
+    @TechRequired = orbitalMegastructures
 }
 @PART[FTT_Structural_500_10]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = colossalRocketry
-}
-@PART[FTT_Tank_1000_01]:NEEDS[CommunityTechTree]
-{
-    @TechRequired = colossalRocketry
-}
-@PART[FTT_Tank_500_01]:NEEDS[CommunityTechTree]
-{
-    @TechRequired = colossalRocketry
-}
-@PART[FTT_Tank_500_02]:NEEDS[CommunityTechTree]
-{
-    @TechRequired = colossalRocketry
-}
-@PART[FTT_Tank_500_03]:NEEDS[CommunityTechTree]
-{
-    @TechRequired = colossalRocketry
-}
-@PART[FTT_Tank_500_04]:NEEDS[CommunityTechTree]
-{
-    @TechRequired = colossalRocketry
+    @TechRequired = orbitalMegastructures
 }
 @PART[FTT_SAS_500]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = colossalRocketry
+    @TechRequired = orbitalMegastructures
 }
 @PART[FTT_SAS_500_02]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = colossalRocketry
+    @TechRequired = orbitalMegastructures
 }
 
 
 //High-Efficiency Nuke - FTT Nuke Engines
 @PART[FTT_Engine_375_03]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = advNuclearPropulsion
+    @TechRequired = expNuclearPropulsion
 }
 @PART[FTT_Engine_375_04]:NEEDS[CommunityTechTree]
 {
@@ -141,24 +108,24 @@
 //Large-Scale Nuclear Power - FTT Reactors
 @PART[FTT_Reactor_500_01]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = largeNuclearPower
+    @TechRequired = fusionPower
 }
 @PART[FTT_Service_375_01]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = largeNuclearPower
+    @TechRequired = advNuclearPower
 }
 
 
 //Experimental Aircraft Engines - All Ducted Fans
 @PART[FTT_DuctedFan_Lg]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = expAircraftEngines
+    @TechRequired = specializedFlightSystems
 }
 @PART[FTT_DuctedFan_Med]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = expAircraftEngines
+    @TechRequired = efficientFlightSystems
 }
 @PART[FTT_Engine_375_02]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = expAircraftEngines
+    @TechRequired = specializedFlightSystems
 }


### PR DESCRIPTION
Updated the CTT patch in order to better reorganize and balance the position of the FTT parts in the Community Tech TechTree.
- Removed the deprecated Kontainer Parts and the old 'StarLifter' Command Module
- Added the 'Orca' Command Module in the specializedCommandModules node
- Moved the 'Honeybadger' Command Module to the heavyCommandModules node
- Moved the 'Honeybadger' Structural Parts to the metaMaterials Node
- Moved the 'Starlifter' Structural Parts and SAS parts to the orbitalMegastructures Node
- Moved the 'Honeybadger' Medium Ducted Fan to the efficientFlightSystems node
- Moved the 'Honeybadger' Large Ducted Fan, Inline Fan and VTOL in the specializedFlightSystems Node
- Moved the 'Honeybadger' Nuclear Reactor to the advNuclearPower node (because it's similar to the 3.75m USI Nuke)
- Moved the 'Starlifter' Nuclear Reactor to the fusionPower node (because it's way more powerful than the 3.75m USI Nuke)
- Moved the 'Starlifter' GNR-2500 Nuclear Engine to the advNuclearPropulsion node (to better balance with stock and other NTR mods)
- Moved the 'Starlifter' GNR-3750 Nuclear Engine to the expNuclearPropulsion node (to better balance with stock and other NTR mods)

I hope this feels more balanced for CTT carrer modes.
Regards,