### PR TITLE
Fix tankCost for Honeybadger

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Cargo_375_01.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Cargo_375_01.cfg
@@ -56,14 +56,15 @@ MODULE
   nextButtonText = Next Cargo
   prevButtonText = Previous Cargo
   statusText = Cargo
-  }
+}
+
 MODULE
 {
   name = FSfuelSwitch
   resourceNames = MetallicOre;Water;Substrate;Minerals;Karbonite;LiquidFuel,Oxidizer;MonoPropellant;Uraninite;MaterialKits;LiquidFuel
   resourceAmounts =        15000;15000;15000;15000;15000;1350,1650;15000;15000;15000;3000
   initialResourceAmounts = 0;0;0;0;0;0,0;0;0;0;0
-  tankCost = 10500;12;4500;12000;4800;1377;3600;10500;15000;1377
+  tankCost = 26400;12;4500;12000;4800;1377;3600;10500;30000;3400
 	basePartMass = 0.5
 	tankMass = 0;0;0;0;0;0;0;0;0;0
   hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Cargo_375_01.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Cargo_375_01.cfg
@@ -64,7 +64,7 @@ MODULE
   resourceNames = MetallicOre;Water;Substrate;Minerals;Karbonite;LiquidFuel,Oxidizer;MonoPropellant;Uraninite;MaterialKits;LiquidFuel
   resourceAmounts =        15000;15000;15000;15000;15000;1350,1650;15000;15000;15000;3000
   initialResourceAmounts = 0;0;0;0;0;0,0;0;0;0;0
-  tankCost = 26400;12;4500;12000;4800;1377;3600;10500;30000;3400
+  tankCost = 26400;12;4500;12000;4800;1377;3600;10500;30000;2400
 	basePartMass = 0.5
 	tankMass = 0;0;0;0;0;0;0;0;0;0
   hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Cargo_375_02.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/Parts/FTT_Cargo_375_02.cfg
@@ -68,13 +68,14 @@ MODULE
   prevButtonText = Previous Cargo
   statusText = Cargo
 }
+
 MODULE
 {
   name = FSfuelSwitch
   resourceNames = MetallicOre;Water;Substrate;Minerals;Karbonite;LiquidFuel,Oxidizer;MonoPropellant;Uraninite;MaterialKits;LiquidFuel
   resourceAmounts = 45000;45000;45000;45000;45000;4050,4950;45000;45000;45000;9000
   initialResourceAmounts = 0;0;0;0;0;0,0;0;0;0;0
-  tankCost = 31500;36;13500;36000;14400;4131;10800;31500;45000;4131
+  tankCost = 79200;36;13500;36000;14400;4131;10800;31500;90000;7200
   basePartMass = 1.5
   tankMass = 0;0;0;0;0;0;0;0;0;0
   hasGUI = false


### PR DESCRIPTION
Fixed tank costs for Honeybadger Cargo Pods to ensure all tanks reflect correct resource costs, and have a proper empty cost (instead of negative values).