### PR TITLE
Add ReStock Whitelist file for FTT 5m SAS part.

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/FTT.restockwhitelist
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/FTT/FTT.restockwhitelist
@@ -1,0 +1,5 @@
+// Whitelist to enable FTT parts when ReStock is installed.
+// See: https://github.com/PorktoberRevolution/ReStocked/wiki/Asset-Blacklist-and-Whitelist
+
+Squad/Parts/Command/advancedSasModuleLarge/
+Squad/Parts/Utility/dockingPortSr/


### PR DESCRIPTION
Whitelist the Vanilla advancedSasModuleLarge & dockingPortSr files to ensure that the 5m SAS part can load correctly alongside ReStock.